### PR TITLE
feat: simplify App component and enhance Canvas collaboration features

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,43 +1,9 @@
-import { useState } from "react";
 import { Canvas } from "./components/Canvas";
 
 function App() {
-    const [roomId, setRoomId] = useState("");
-    const [joined, setJoined] = useState(false);
-
-    const handleJoin = () => {
-        if (!roomId.trim()) {
-            alert("Please enter a valid Room ID");
-            return;
-        }
-        setJoined(true);
-    };
 
     return (
-        <main className="w-full h-screen flex items-center justify-center bg-gray-100">
-            {!joined ? (
-                <div className="flex flex-col items-center gap-4 p-6 bg-white rounded-xl shadow-md">
-                    <h1 className="text-2xl font-bold text-gray-800">
-                        Join a Drawing Room
-                    </h1>
-                    <input
-                        type="text"
-                        placeholder="Enter Room ID"
-                        value={roomId}
-                        onChange={(e) => setRoomId(e.target.value)}
-                        className="border border-gray-300 rounded-lg px-4 py-2 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                    <button
-                        onClick={handleJoin}
-                        className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg font-medium transition-all"
-                    >
-                        Join Room
-                    </button>
-                </div>
-            ) : (
-                <Canvas roomId={roomId} />
-            )}
-        </main>
+        <><Canvas/></>
     );
 }
 


### PR DESCRIPTION
## Description

> Currently, when users visit the homepage, they are immediately prompted to join a collaboration room before they can start drawing.
This creates a poor user experience. This PR implements a local-first drawing mode where users can begin sketching right away, and choose to collaborate only when they explicitly opt in.

1.Local-First Experience
-Removed the “Join Room” modal from automatically appearing on page load.
-The app now opens directly to a blank canvas ready for drawing.
-No socket connections or events are triggered until collaboration is enabled.
2.Collaborate Button
-Added a new “Collaborate” / “Join Room” button in the toolbar.
-When clicked, this opens the room-joining modal where the user can enter a room ID to start collaborating.
3.Dynamic Collaboration Toggle
-Once a user joins or creates a room:
-WebSocket communication is activated.
-All drawing actions are synchronized in real time across connected clients.
-If not joined, drawing actions stay completely local and are not emitted.
4. Disabled Sockets in Local Mode
-In the default local mode, socket.emit() calls are conditionally blocked (if (joined && socket) checks added).

<img width="1902" height="917" alt="image" src="https://github.com/user-attachments/assets/b2ef7ce3-3cb5-48d6-8407-940608aee3b6" />
<img width="1898" height="884" alt="image" src="https://github.com/user-attachments/assets/80158e1c-bc04-4e11-8c20-a0909f7b7cf0" />


## Semver Changes

- [ ] Patch (bug fix, no new features)
- [ ] Minor (new features, no breaking changes)
- [x] Major (breaking changes)

## Issues

> #26 

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).

