### PR TITLE
feat: implemeted pan and zoom

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -67,6 +67,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1912,6 +1913,7 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1922,6 +1924,7 @@
       "integrity": "sha512-/EEvYBdT3BflCWvTMO7YkYBHVE9Ci6XdqZciZANQgKpaiDRGOLIlRo91jbTNRQjgPFWVaRxcYc0luVNFitz57A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1960,6 +1963,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2092,6 +2096,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -2557,6 +2562,7 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3726,6 +3732,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3802,6 +3809,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3811,6 +3819,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4255,6 +4264,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
       "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/client/src/components/Canvas.jsx
+++ b/client/src/components/Canvas.jsx
@@ -16,7 +16,16 @@ export const Canvas = () => {
   const startPoint = useRef({ x: 0, y: 0 });
   const snapshot = useRef(null);
 
-  // Collaboration
+  // --- Pan and Zoom State ---
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [isPanning, setIsPanning] = useState(false);
+  const [isPointerDown, setIsPointerDown] = useState(false);
+  const lastMousePos = useRef({ x: 0, y: 0 });
+  // Ref to store the latest canvas state for redraws
+  const canvasImage = useRef(null);
+
+  // --- Collaboration State ---
   const [roomId, setRoomId] = useState("");
   const [joined, setJoined] = useState(false);
   const [socket, setSocket] = useState(null);
@@ -27,6 +36,7 @@ export const Canvas = () => {
   );
 
   const handleLogout = async () => {
+    // ... (existing logout logic - unchanged)
     const token = localStorage.getItem("token");
     if (!token) return;
     try {
@@ -49,6 +59,63 @@ export const Canvas = () => {
     }
   };
 
+  // --- Helper Function: Screen to World Coordinates ---
+  /**
+   * Converts mouse event coordinates (screen space) to canvas
+   * coordinates (world space) respecting scale and offset.
+   */
+  const getWorldPoint = (e) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+    const screenX = e.clientX - rect.left;
+    const screenY = e.clientY - rect.top;
+    return {
+      x: (screenX - offset.x) / scale,
+      y: (screenY - offset.y) / scale,
+    };
+  };
+
+  // --- Redraw canvas on Pan or Zoom ---
+  /**
+   * This effect redraws the entire canvas whenever scale or offset changes.
+   * It preserves the destructive drawing by saving/redrawing the canvas content.
+   */
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!ctx || !canvasImage.current) return;
+
+    const img = new Image();
+    img.src = canvasImage.current;
+    img.onload = () => {
+      ctx.save();
+      // Reset transform to clear and draw the image
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      // Apply the new transform
+      ctx.translate(offset.x, offset.y);
+      ctx.scale(scale, scale);
+      // Draw the saved canvas content
+      ctx.drawImage(img, 0, 0);
+      ctx.restore();
+      // Re-apply settings for subsequent draws
+      ctx.lineCap = "round";
+      ctx.lineJoin = "round";
+    };
+  }, [scale, offset]);
+
+  // --- Save Canvas State ---
+  /**
+   * Saves the canvas state to the ref.
+   * This is called after any drawing operation.
+   */
+  const saveCanvasState = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvasImage.current = canvas.toDataURL();
+  };
+
   useEffect(() => {
     const s = io("http://localhost:3000");
     setSocket(s);
@@ -57,83 +124,199 @@ export const Canvas = () => {
       if (!joined) return;
       const ctx = canvasRef.current?.getContext("2d");
       if (!ctx) return;
+
+      // Apply current transform for socket drawings
+      ctx.save();
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.translate(offset.x, offset.y);
+      ctx.scale(scale, scale);
+
       if (type === "start") ctx.beginPath();
       ctx.strokeStyle = tool === "eraser" ? "#ffffff" : color;
       ctx.lineWidth = tool === "eraser" ? width * 3 : width;
       ctx.lineTo(x, y);
       ctx.stroke();
+
+      ctx.restore(); // Restore to default transform
+      saveCanvasState(); // Save state after remote draw
     });
     return () => s.disconnect();
-  }, [joined]);
+  }, [joined, scale, offset]); // Add scale/offset dependencies
 
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
     ctx.lineCap = "round";
     ctx.lineJoin = "round";
+
+    // Initial canvas save
+    saveCanvasState();
+
     const handleResize = () => {
-      const image = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const img = new Image();
+      // Use the saved image ref for resizing
+      if (canvasImage.current) {
+        img.src = canvasImage.current;
+      }
+
+      const oldWidth = canvas.width;
+      const oldHeight = canvas.height;
       canvas.width = window.innerWidth;
       canvas.height = window.innerHeight;
-      ctx.putImageData(image, 0, 0);
+
+      // Re-apply transform and draw image
+      ctx.save();
+      ctx.setTransform(1, 0, 0, 1, 0, 0); // Reset
+      ctx.translate(offset.x, offset.y);
+      ctx.scale(scale, scale);
+      if (img.src) {
+        // Draw the image, scaling it to fit the old "world" size if needed
+        // This simple redraw at (0,0) is usually sufficient for bitmap
+        ctx.drawImage(img, 0, 0);
+      }
+      ctx.restore();
+
+      // Re-apply settings
+      ctx.lineCap = "round";
+      ctx.lineJoin = "round";
+
+      // Save new state after resize
+      saveCanvasState();
     };
+
     window.addEventListener("resize", handleResize);
     toast.success("Canvas ready! Local mode active.");
     return () => window.removeEventListener("resize", handleResize);
-  }, []);
+  }, []); // Remove scale/offset, handled by resize
 
   useEffect(() => {
+    // ... (existing keydown logic for tools - unchanged)
     const handleKeyDown = (e) => {
       if (!isCanvasFocused) return;
-      if (e.key === "p" || e.key === "P" || e.key === "1") handleToolChange("pen");
-      else if (e.key === "e" || e.key === "E" || e.key === "2") handleToolChange("eraser");
-      else if (e.key === "l" || e.key === "L" || e.key === "3") handleToolChange("line");
+      if (e.key === "p" || e.key === "P" || e.key === "1")
+        handleToolChange("pen");
+      else if (e.key === "e" || e.key === "E" || e.key === "2")
+        handleToolChange("eraser");
+      else if (e.key === "l" || e.key === "L" || e.key === "3")
+        handleToolChange("line");
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isCanvasFocused]);
 
-  // Drawing logic handlers
+  // --- Panning Listeners (Spacebar) ---
+  useEffect(() => {
+    const handleSpaceDown = (e) => {
+      if (e.key === " ") {
+        e.preventDefault();
+        setIsPanning(true);
+      }
+    };
+    const handleSpaceUp = (e) => {
+      if (e.key === " ") {
+        e.preventDefault();
+        setIsPanning(false);
+      }
+    };
+    window.addEventListener("keydown", handleSpaceDown);
+    window.addEventListener("keyup", handleSpaceUp);
+    return () => {
+      window.removeEventListener("keydown", handleSpaceDown);
+      window.removeEventListener("keyup", handleSpaceUp);
+    };
+  }, []);
+
+  // --- Drawing Logic Handlers (MODIFIED) ---
+
   const startDrawing = (e) => {
+    setIsPointerDown(true);
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext("2d");
     if (!ctx) return;
-    const rect = canvas.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
+
+    // Apply transform before drawing
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.translate(offset.x, offset.y);
+    ctx.scale(scale, scale);
+
+    const { x, y } = getWorldPoint(e);
+    lastMousePos.current = { x: e.clientX, y: e.clientY };
+
+    if (isPanning) {
+      // Panning logic is handled in `draw`
+      ctx.restore();
+      return;
+    }
+
     startPoint.current = { x, y };
     setIsDrawing(true);
+
     if (activeTool === "pen" || activeTool === "eraser") {
       ctx.beginPath();
       ctx.moveTo(x, y);
       if (joined && socket)
         socket.emit("draw", {
           roomId,
-          x,
-          y,
+          x, // Send WORLD coordinates
+          y, // Send WORLD coordinates
           type: "start",
           color: activeColor,
           width: strokeWidth,
           tool: activeTool,
         });
     }
+
     // Save snapshot for preview tools
     if (activeTool === "line" || activeTool === "rectangle") {
+      // Snapshot must be taken from the *un-transformed* context
+      ctx.restore(); // Restore *before* getImageData
       snapshot.current = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      // Re-save to apply transform again for next draw
+      ctx.save();
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.translate(offset.x, offset.y);
+      ctx.scale(scale, scale);
     }
+    ctx.restore(); // Restore transform
   };
 
   const draw = (e) => {
-    if (!isDrawing) return;
+    if (!isPointerDown) return;
+
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext("2d");
     if (!ctx) return;
-    const rect = canvas.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
+
+    // Apply transform
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.translate(offset.x, offset.y);
+    ctx.scale(scale, scale);
+
+    const { x, y } = getWorldPoint(e);
+
+    // --- Handle Panning ---
+    if (isPanning) {
+      const dx = e.clientX - lastMousePos.current.x;
+      const dy = e.clientY - lastMousePos.current.y;
+      setOffset((prev) => ({ x: prev.x + dx, y: prev.y + dy }));
+      lastMousePos.current = { x: e.clientX, y: e.clientY };
+      ctx.restore();
+      return;
+    }
+
+    if (!isDrawing) {
+      ctx.restore();
+      return;
+    }
+
+    // --- Handle Drawing ---
     if (activeTool === "pen" || activeTool === "eraser") {
       ctx.strokeStyle = activeTool === "eraser" ? "#ffffff" : activeColor;
       ctx.lineWidth = activeTool === "eraser" ? strokeWidth * 3 : strokeWidth;
@@ -142,49 +325,105 @@ export const Canvas = () => {
       if (joined && socket)
         socket.emit("draw", {
           roomId,
-          x,
-          y,
+          x, // Send WORLD coordinates
+          y, // Send WORLD coordinates
           type: "move",
           color: activeColor,
           width: strokeWidth,
           tool: activeTool,
         });
-    } else if (activeTool === "line") {
-      ctx.putImageData(snapshot.current, 0, 0);
+    } else if (activeTool === "line" || activeTool === "rectangle") {
+      // --- Snapshot logic ---
+      // 1. Restore to default transform to draw snapshot
+      ctx.restore();
+      if (snapshot.current) {
+        ctx.putImageData(snapshot.current, 0, 0);
+      }
+      // 2. Save and re-apply panned/zoomed transform
+      ctx.save();
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.translate(offset.x, offset.y);
+      ctx.scale(scale, scale);
+
+      // 3. Draw the preview shape in WORLD space
       ctx.beginPath();
-      ctx.moveTo(startPoint.current.x, startPoint.current.y);
-      ctx.lineTo(x, y);
       ctx.strokeStyle = activeColor;
       ctx.lineWidth = strokeWidth;
+
+      if (activeTool === "line") {
+        ctx.moveTo(startPoint.current.x, startPoint.current.y);
+        ctx.lineTo(x, y);
+      } else if (activeTool === "rectangle") {
+        const startX = startPoint.current.x;
+        const startY = startPoint.current.y;
+        const width = x - startX;
+        const height = y - startY;
+        ctx.strokeRect(startX, startY, width, height);
+      }
       ctx.stroke();
       ctx.closePath();
-    } else if (activeTool === "rectangle") {
-      ctx.putImageData(snapshot.current, 0, 0);
-      ctx.beginPath();
-      const startX = startPoint.current.x;
-      const startY = startPoint.current.y;
-      const width = x - startX;
-      const height = y - startY;
-      ctx.strokeStyle = activeColor;
-      ctx.lineWidth = strokeWidth;
-      ctx.strokeRect(startX, startY, width, height);
-      ctx.closePath();
     }
+
+    ctx.restore(); // Restore transform
   };
 
   const stopDrawing = () => {
+    setIsPointerDown(false);
+    if (!isDrawing) return; // Don't save if we were just panning
+
     setIsDrawing(false);
     const ctx = canvasRef.current?.getContext("2d");
-    if (ctx) ctx.closePath();
+    if (ctx) {
+      ctx.closePath();
+      saveCanvasState(); // Save the final state
+    }
+  };
+
+  // --- Zoom Handler (Mouse Wheel) ---
+  const handleWheel = (e) => {
+    e.preventDefault();
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const rect = canvas.getBoundingClientRect();
+    const screenX = e.clientX - rect.left;
+    const screenY = e.clientY - rect.top;
+
+    // Mouse position in world space before zoom
+    const worldX = (screenX - offset.x) / scale;
+    const worldY = (screenY - offset.y) / scale;
+
+    // Zoom factor
+    const delta = e.deltaY > 0 ? 0.9 : 1.1;
+    const newScale = Math.min(Math.max(scale * delta, 0.5), 3);
+
+    // New offset to keep worldX/worldY at the same screenX/screenY
+    const newOffsetX = screenX - worldX * newScale;
+    const newOffsetY = screenY - worldY * newScale;
+
+    setScale(newScale);
+    setOffset({ x: newOffsetX, y: newOffsetY });
   };
 
   const handleClear = () => {
     const ctx = canvasRef.current?.getContext("2d");
     if (!ctx || !canvasRef.current) return;
+    // Reset transform before clearing
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+    ctx.restore();
+    // Re-apply current transform (which will be blank)
+    ctx.save();
+    ctx.translate(offset.x, offset.y);
+    ctx.scale(scale, scale);
+    ctx.restore();
+
+    saveCanvasState(); // Save the cleared state
     toast.success("Canvas cleared!");
   };
 
+  // --- Collaboration Handlers (Unchanged) ---
   const handleJoinRoom = () => {
     if (!roomId.trim() || !socket) return;
     socket.emit("join-room", roomId.trim());
@@ -206,63 +445,68 @@ export const Canvas = () => {
     }
   };
 
+  // Determine cursor based on state
+  const getCursor = () => {
+    if (isPanning) {
+      return isPointerDown ? "cursor-grabbing" : "cursor-grab";
+    }
+    return "cursor-crosshair";
+  };
+
   return (
     <div className="relative w-full h-screen overflow-hidden bg-canvas">
-
-{/* 🔹 Login / Logout buttons */}
-<div className="fixed top-4 left-4 z-[9999]">
-  {isLoggedIn ? (
-    // Logout button if logged in
-    <button
-      onClick={handleLogout}
-      className="bg-red-600 text-white px-4 py-2 rounded-lg shadow hover:bg-red-700"
-    >
-      Logout
-    </button>
-  ) : (
-    <>
-      {/* Desktop view: two separate buttons */}
-      <div className="hidden sm:flex gap-3">
-        <button
-          onClick={() => window.location.href = "/login"}
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg shadow hover:bg-blue-700"
-        >
-          Sign In
-        </button>
-        <button
-          onClick={() => window.location.href = "/register"}
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg shadow hover:bg-blue-700"
-        >
-          Sign Up
-        </button>
+      {/* 🔹 Login / Logout buttons (Unchanged) */}
+      <div className="fixed top-4 left-4 z-[9999]">
+        {isLoggedIn ? (
+          // ... (logout button)
+          <button
+            onClick={handleLogout}
+            className="bg-red-600 text-white px-4 py-2 rounded-lg shadow hover:bg-red-700"
+          >
+            Logout
+          </button>
+        ) : (
+          <>
+            {/* ... (desktop login/signup buttons) */}
+            <div className="hidden sm:flex gap-3">
+              <button
+                onClick={() => (window.location.href = "/login")}
+                className="bg-blue-600 text-white px-4 py-2 rounded-lg shadow hover:bg-blue-700"
+              >
+                Sign In
+              </button>
+              <button
+                onClick={() => (window.location.href = "/register")}
+                className="bg-blue-600 text-white px-4 py-2 rounded-lg shadow hover:bg-blue-700"
+              >
+                Sign Up
+              </button>
+            </div>
+            {/* ... (mobile login/signup dropdown) */}
+            <div className="sm:hidden relative">
+              <details className="bg-blue-600 text-white px-4 py-2 rounded-lg shadow cursor-pointer select-none">
+                <summary className="outline-none list-none">Menu ☰</summary>
+                <div className="absolute left-0 mt-2 w-32 bg-white text-black rounded-lg shadow-lg border">
+                  <button
+                    onClick={() => (window.location.href = "/login")}
+                    className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                  >
+                    Sign In
+                  </button>
+                  <button
+                    onClick={() => (window.location.href = "/register")}
+                    className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                  >
+                    Sign Up
+                  </button>
+                </div>
+              </details>
+            </div>
+          </>
+        )}
       </div>
 
-      {/* Mobile view: dropdown */}
-      <div className="sm:hidden relative">
-        <details className="bg-blue-600 text-white px-4 py-2 rounded-lg shadow cursor-pointer select-none">
-          <summary className="outline-none list-none">Menu ☰</summary>
-          <div className="absolute left-0 mt-2 w-32 bg-white text-black rounded-lg shadow-lg border">
-            <button
-              onClick={() => window.location.href = "/login"}
-              className="block w-full text-left px-4 py-2 hover:bg-gray-100"
-            >
-              Sign In
-            </button>
-            <button
-              onClick={() => window.location.href = "/register"}
-              className="block w-full text-left px-4 py-2 hover:bg-gray-100"
-            >
-              Sign Up
-            </button>
-          </div>
-        </details>
-      </div>
-    </>
-  )}
-</div>
-
-
-
+      {/* --- UI Elements (Unchanged) --- */}
       <Toolbar
         activeTool={activeTool}
         onToolChange={handleToolChange}
@@ -288,6 +532,8 @@ export const Canvas = () => {
         strokeWidth={strokeWidth}
         onStrokeWidthChange={setStrokeWidth}
       />
+
+      {/* --- Canvas Element (MODIFIED) --- */}
       <canvas
         ref={canvasRef}
         tabIndex={0}
@@ -297,8 +543,11 @@ export const Canvas = () => {
         onMouseMove={draw}
         onMouseUp={stopDrawing}
         onMouseLeave={stopDrawing}
-        className="cursor-crosshair focus:outline-2 focus:outline-primary"
+        onWheel={handleWheel} // Added wheel handler
+        className={`${getCursor()} focus:outline-2 focus:outline-primary`} // Dynamic cursor
       />
+
+      {/* --- Modal and Info (Unchanged) --- */}
       {isModalOpen && (
         <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white/90 border border-gray-400 rounded-xl shadow-xl p-6 z-50 flex flex-col items-center gap-3">
           <h2 className="text-xl font-semibold">Join a Room</h2>


### PR DESCRIPTION
## Description

Implemented **Pan and Zoom functionality** for the Infinite Canvas to improve navigation and usability.

- **Pan:** Users can hold the **Spacebar** and drag the mouse to move around the canvas. The cursor changes to a grabbing 🖐️ icon while panning.  
- **Zoom:** Users can use the **mouse scroll wheel** to zoom in and out, centered on the cursor position.  
- **State Management:** The canvas’s **scale (zoom level)** and **offset (pan position)** are managed in the component’s state.  
- **Rendering:** Drawing tools (pen, shapes, etc.) respect the current zoom and pan state for accurate rendering.

## Semver Changes

- [ ] Patch (bug fix, no new features)
- [ ] Minor (new features, no breaking changes)
- [x] Major (breaking changes)

## Issues

Closes #27  – *Implement Pan and Zoom for Infinite Canvas*

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md)
