### PR TITLE
bug: fixed logout button in frontend added handle logout logic

### DIFF
--- a/client/src/components/Canvas.jsx
+++ b/client/src/components/Canvas.jsx
@@ -52,7 +52,34 @@ export const Canvas = () => {
   const [hoveredHandle, setHoveredHandle] = useState(null); // { id, dir }
 
   const handleLogout = async () => {
-    // placeholder
+    try {
+      const token = localStorage.getItem("token");
+      if (!token) {
+        toast.error("You are not logged in.");
+        return;
+      }
+
+      const res = await fetch("http://localhost:3000/api/auth/logout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.message || "Logout failed");
+        return;
+      }
+
+      // Clear auth state and redirect
+      localStorage.removeItem("token");
+      setIsLoggedIn(false);
+      toast.success("Logged out successfully");
+      window.location.href = "/";
+    } catch (err) {
+      console.error("Logout error:", err);
+      toast.error("Logout failed. Please try again.");
+    }
   };
 
   // --- Helpers ---


### PR DESCRIPTION
## Description

This PR fixes the logout functionality by adding proper frontend logic to handle user logout. It checks for an existing token, sends a logout request to the backend, clears authentication state, and redirects the user to the home page upon success.

## Semver Changes

* [x] Patch (bug fix, no new features)
* [ ] Minor (new features, no breaking changes)
* [ ] Major (breaking changes)

## Issues

Closes #57 

## Checklist

* [x] Added frontend logout handler (`handleLogout`)
* [x] Fixed logout button functionality
* [x] Implemented toast notifications for success/error states
* [x] Cleared local storage and updated auth state on logout
* [x] I have read the [[Contributing Guidelines](https://chatgpt.com/Contributor_Guide/Contruting.md)](../Contributor_Guide/Contruting.md)
