### PR TITLE
feat: add text tool to toolbar and enhance shape handling in canvas

### DIFF
--- a/client/src/components/Toolbar.jsx
+++ b/client/src/components/Toolbar.jsx
@@ -12,6 +12,7 @@ import {
   Brush,
   SquareDashed, // New import for the area select tool
   ImagePlus,
+  Type
 } from "lucide-react";
 import { cn } from "../lib/utils";
 import { Button } from "./ui/Button";
@@ -31,6 +32,7 @@ export const Toolbar = ({
   const tools = [
     { type: "select", icon: MousePointer2 },
     { type: "area-select", icon: SquareDashed }, // New Area Select Tool
+    {type:"text",icon:Type},
     { type: "pen", icon: Pen },
     { type: "eraser", icon: Eraser },
     { type: "rectangle", icon: Square },


### PR DESCRIPTION
## Description

> I have implemented the text tool functionality . On clicking the text tool we get a textbox to write the text in that and it can be resized and dragged as required.
>Used the idea of trimming the text according to the dynamic sizing of textbox and determining font size accordingly . 
>It also lets the whole content fit in the textbox without any overflow both lengthwise as well as heightwise.
>On selecting select tool and single clicking over text we get to resize or drag the textbox however on double clicking we get to edit the text as required .
>We commit our text to the canvas after we finish writing/editing our text and click elsewhere.

<img width="1907" height="904" alt="image" src="https://github.com/user-attachments/assets/2635279c-c315-44aa-966d-905c6a3c92a2" />


## Semver Changes

- [ ] Patch (bug fix, no new features)
- [x] Minor (new features, no breaking changes)
- [ ] Major (breaking changes)

## Issues

> #61 

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).

