### PR TITLE
feat: dockerized the whole project

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,45 @@ collab-canvas/
 ## 🚀 Getting Started
 
 Follow these steps to set up and run the project locally.
+- **Option 1: Docker (Recommended)** – The simplest way to get running with a single command.  
+- **Option 2: Manual Setup** – The traditional way if you want to manage the services yourself.
+
+## Option 1: Run with Docker (Recommended) 🐳
+
+This method starts the **client**, **server**, and a **MongoDB database** all at once.  
+You do **not** need Node.js or MongoDB installed on your machine.
+### Prequisites: you must have docker desktop installed and running 
+
+### Clone the Repository
+
+```bash
+git clone https://github.com/your-username/collab-canvas.git
+cd collab-canvas
+```
+
+### Run with Docker Compose
+
+```bash
+docker-compose up --build
+```
+
+Docker will build the images and start all three containers.
+
+Your application is now running:
+
+Frontend Client: http://localhost:3000
+
+Backend Server: http://localhost:5000
+
+MongoDB Database: Accessible to the server at mongodb://db:27017
+
+Note: The first build may take a few minutes. Subsequent builds will be faster.
+To stop all services, press Ctrl + C in your terminal, then run:
+```bash
+docker-compose down
+```
+
+## Option 2
 
 ### Prerequisites
 

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/client/src/components/StrokeControl.jsx
+++ b/client/src/components/StrokeControl.jsx
@@ -1,5 +1,4 @@
-import { Slider } from "./ui/slider";
-
+import { Slider } from "./ui/Slider";
 export const StrokeControl = ({ strokeWidth, onStrokeWidthChange }) => {
     return (
         <div className="fixed right-6 top-1/2 -translate-y-1/2 z-50">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+
+  client:
+    build: ./client
+    ports:
+      - "3000:5173"
+    depends_on:
+      - server
+
+  server:
+    build: ./server
+    ports:
+      - "${SERVER_PORT:-5000}:5000"
+    environment:
+      PORT: 5000
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
+      MONGO_URI: ${MONGO_URI:-mongodb://db:27017/collabcanvas}
+      JWT_SECRET: ${JWT_SECRET:-THIS_IS_A_DEFAULT_NOT_A_SECRET}
+    depends_on:
+      - db
+  
+  db:
+    image: mongo:latest
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+
+volumes:
+  mongo-data:

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,4 @@
+PORT=3000
+MONGO_URI=your_mongodb_connection_string_here
+CORS_ORIGIN=http://localhost:5173
+JWT_SECRET=your_jwt_secret_here

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 5000
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
# Description

This pull request containerizes the entire CollabCanvas application using Docker and Docker Compose. It fulfills the goal of the original issue (#67) by replacing the complex, multi-step manual setup with a simple, one-command startup.

Instead of requiring developers to manage two separate terminals and a manual database connection, they can now clone the repo and run:

```bash
docker-compose up --build
```

# This PR Adds

- `docker-compose.yml`: Orchestrates the client, server, and db services.
- `client/Dockerfile`: Containerizes the Vite frontend.
- `server/Dockerfile`: Containerizes the Node.js backend.
- `.dockerignore` files: To speed up build times and ignore `node_modules`.
- `.env.example`: A root template for environment variables.
- A new "Getting Started" section in the `README.md` explaining the Docker-based workflow.

This PR also includes the necessary code fixes to make the app work inside the Docker environment:

- Upgraded the base image to `node:20-alpine` in both Dockerfiles, as required by the newer version of Vite.
- Updated the port mapping in `docker-compose.yml` to `3000:5173` to correctly match the Vite server.

# Semver Changes

- [ ] Patch (bug fix, no new features)
- [x] Minor (new features, no breaking changes)
- [ ] Major (breaking changes)

# Issues

Closes #67

# Checklist

- [x] I have read the Contributing Guidelines.
